### PR TITLE
Update Todoist API from deprecated v2/v9 to current v1/v10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .aider*
+__pycache__/
+*.pyc
+*.pyo
+*.pyd

--- a/gh-todoist.py
+++ b/gh-todoist.py
@@ -8,7 +8,7 @@
 # ]
 # ///
 """
-Cron-friendly GitHub→Todoist sync using gh(1) + Todoist REST v2.
+Cron-friendly GitHub→Todoist sync using gh(1) + Todoist API v1.
 
 Env:
   TODOIST_API_TOKEN  (required)
@@ -238,10 +238,10 @@ def gh_pr_merged(url: str, gh_path: Optional[str]) -> Optional[bool]:
         log.warning("gh_pr_merged_failed", url=url, error=str(e))
         return None
 
-# ---------- Todoist REST v2 ----------
+# ---------- Todoist API v1 ----------
 
 class Todoist:
-    def __init__(self, token: str, base_url: str = "https://api.todoist.com/rest/v2"):
+    def __init__(self, token: str, base_url: str = "https://api.todoist.com/api/v1"):
         self.base = base_url.rstrip("/")
         self.h = {"Authorization": f"Bearer {token}", "Content-Type":"application/json"}
         self.cli = httpx.Client(timeout=30)

--- a/todoist_completed_report.py
+++ b/todoist_completed_report.py
@@ -38,8 +38,8 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 
-API_BASE_SYNC = "https://api.todoist.com/sync/v9"
-API_BASE_REST = "https://api.todoist.com/rest/v2"
+API_BASE_SYNC = "https://api.todoist.com/sync/v10"
+API_BASE_REST = "https://api.todoist.com/api/v1"
 
 
 def _local_tz():
@@ -240,7 +240,7 @@ def resolve_project_id_by_name(projects: Dict[str, str], name: str) -> Optional[
 
 def fetch_projects_full(token: str) -> List[Dict[str, Any]]:
     """
-    Return raw project objects from Todoist REST v2, including parent_id.
+    Return raw project objects from Todoist API v1, including parent_id.
     """
     url = f"{API_BASE_REST}/projects"
     headers = {"Authorization": f"Bearer {token}"}
@@ -370,7 +370,7 @@ def fetch_completed(
 
 def fetch_task_detail(token: str, task_id: str) -> Optional[Dict[str, Any]]:
     """
-    Fetch a single task (including completed/archived) via REST v2.
+    Fetch a single task (including completed/archived) via API v1.
     Returns the task dict or None if not found.
     """
     url = f"{API_BASE_REST}/tasks/{task_id}"


### PR DESCRIPTION
Todoist deprecated and removed their REST API v2 and Sync API v9 on
2026-02-10. This commit migrates the codebase to use the current API
versions:

- REST API: https://api.todoist.com/rest/v2 → https://api.todoist.com/api/v1
- Sync API: https://api.todoist.com/sync/v9 → https://api.todoist.com/sync/v10

Changes:
- gh-todoist.py: Updated base URL and comments for Todoist API v1
- todoist_completed_report.py: Updated both REST and Sync API base URLs

The endpoint paths remain the same (/tasks, /projects, /labels, etc.),
only the base URL structure has changed.

https://claude.ai/code/session_018ckmjBDdgtfpoxButKKW6q